### PR TITLE
fix `terraform fmt` path

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -122,6 +122,7 @@ jobs:
           terraform fmt \
             -check \
             -recursive
+        working-directory: ${{ github.workspace }}
 
       - name: Terraform Init
         run: |


### PR DESCRIPTION
## What
`terraform fmt` の実行ディレクトリを変更した。

## Why
以下のようなディレクトリ構造の場合、`./staging` で `terraform fmt -recursive` しても `./module` 内の `.tf` ファイルが整形されないため。

```
.
├── module
├── production
└── staging
```

## How

## Ref
