### PR TITLE
cronジョブでブランチを指定可能にした

### DIFF
--- a/.github/workflows/terraform-plan-cron.yml
+++ b/.github/workflows/terraform-plan-cron.yml
@@ -7,6 +7,10 @@ on:
         description: ワーキングディレクトリ
         type: string
         required: true
+      ref:
+        description: CIを実行するブランチ名
+        type: string
+        required: true
       aws-region:
         description: AWSのリージョン名
         type: string
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: GCP認証その1
         if: inputs.gcp-project-id

--- a/.github/workflows/terraform-plan-cron.yml
+++ b/.github/workflows/terraform-plan-cron.yml
@@ -10,7 +10,8 @@ on:
       ref:
         description: CIを実行するブランチ名
         type: string
-        required: true
+        required: false
+        default: ''
       aws-region:
         description: AWSのリージョン名
         type: string


### PR DESCRIPTION
# 背景

cron(sheduleタイプのトリガー)は、実行がデフォルトブランチで実行されます([GITHUB_REF = デフォルトブランチ](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#schedule))。

しかし、このcronjobは任意のブランチで実行したいケースがあります。
例えばデフォルトブランチを `staging` ブランチ、それとは別に `production` ブランチがあるとして、 ステージング環境を `staging` ブランチ、 本番環境を `production` ブランチへ一致させているとします。
このworkflowは実際のインフラが特定のブランチとずれていないかを検証するものなので、ステージング環境に対しては `staging` ブランチ、 本番環境に対しては `production` ブランチで実行したいはずです。
しかし、現状は利用するブランチにデフォルトブランチしか使えないため、上の例ではステージング環境しかチェックできない、またはまだ本番環境に適用されていないインフラ定義(in `staging` ブランチ)で本番環境へ検証されてしまいます。

# 修正内容

workflowの引数でブランチ名を取れるようにして、checkoutアクションに渡しています。